### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-release-nodejs-sample.yaml
+++ b/.github/workflows/build-release-nodejs-sample.yaml
@@ -36,6 +36,9 @@ jobs:
   test:
     name: Test
     uses: ./.github/workflows/test.yaml
+    permissions:
+      contents: read
+      actions: read
   build-publish:
     name: Build and publish
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/bcgov/nr-nodejs-sample/security/code-scanning/12](https://github.com/bcgov/nr-nodejs-sample/security/code-scanning/12)

Add an explicit `permissions` block to the `test` job in `.github/workflows/build-release-nodejs-sample.yaml`.

Best fix (without changing behavior): set minimal read permissions for typical test execution and reusable workflow invocation:
- `contents: read`
- `actions: read`

This mirrors the explicit least-privilege style already used in `preflight`, keeps behavior consistent, and satisfies CodeQL by preventing fallback to broader defaults.

Edit region: around lines 36–39 in `.github/workflows/build-release-nodejs-sample.yaml`, directly under the `test` job’s `uses` line.

No imports, methods, or dependency changes are needed (YAML workflow-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
